### PR TITLE
Coin detail polish: price formatting, chart fix, markets layout, draggable watermark

### DIFF
--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/core/presentation/util/NumberFormatting.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/core/presentation/util/NumberFormatting.kt
@@ -1,17 +1,49 @@
 package com.cryptodanilo.project.core.presentation.util
 
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+
+data class DisplayableNumber(
+    val value: Double,
+    val formatted: String,
+)
+
+fun Double.toDisplayableNumber(): DisplayableNumber {
+    val sign = if (this < 0) "-" else ""
+    val abs = kotlin.math.abs(this)
+    val integerPart =
+        abs
+            .toLong()
+            .toString()
+            .reversed()
+            .chunked(3)
+            .joinToString(",")
+            .reversed()
+    val fractionalPart = ((abs - abs.toLong()) * 100).toLong().toString().padStart(2, '0')
+    return DisplayableNumber(value = this, formatted = "$sign$integerPart.$fractionalPart")
+}
+
 fun Double.toAbbreviatedDollarString(): String {
     val (divisor, suffix) =
         when {
+            this >= 1_000_000_000_000 -> 1_000_000_000_000.0 to "T"
             this >= 1_000_000_000 -> 1_000_000_000.0 to "B"
             this >= 1_000_000 -> 1_000_000.0 to "M"
             this >= 1_000 -> 1_000.0 to "K"
-            else -> return "$ ${this.toLong()}"
+            else -> return "$ ${this.toDisplayableNumber().formatted}"
         }
     val divided = kotlin.math.abs(this / divisor)
     val intPart = divided.toLong()
-    val fracPart = ((divided - intPart) * 10).toInt()
-    return "$ $intPart.${fracPart}$suffix"
+    val fracPart = ((divided - intPart) * 100).roundToInt()
+    val (finalIntPart, finalFracPart) =
+        if (fracPart == 100) {
+            (intPart + 1) to 0
+        } else {
+            intPart to fracPart
+        }
+    val fracPartString = finalFracPart.toString().padStart(2, '0')
+    return "$ $finalIntPart.${fracPartString}$suffix"
 }
 
 fun Long.toAbbreviatedString(): String =
@@ -30,6 +62,68 @@ fun Long.toAbbreviatedString(): String =
         }
         else -> this.toString()
     }
+
+private fun Double.toCommaFormattedString(decimals: Int): String {
+    val sign = if (this < 0) "-" else ""
+    val abs = kotlin.math.abs(this)
+    val factor = 10.0.pow(decimals)
+    val rounded = (abs * factor).roundToLong()
+    val factorLong = factor.toLong()
+    val integerPart = rounded / factorLong
+    val fractionalPart = rounded % factorLong
+    val integerFormatted =
+        integerPart
+            .toString()
+            .reversed()
+            .chunked(3)
+            .joinToString(",")
+            .reversed()
+    return if (decimals == 0) {
+        "$sign$integerFormatted"
+    } else {
+        "$sign$integerFormatted.${fractionalPart.toString().padStart(decimals, '0')}"
+    }
+}
+
+// Always shows the full number with thousand separators — used for the coin list,
+// where prices must never be abbreviated. Small altcoin prices need more decimal
+// places than whole-dollar prices to remain meaningful (e.g. 0.000142).
+fun Double.formatFullPrice(): String {
+    val abs = kotlin.math.abs(this)
+    val decimals =
+        when {
+            abs < 0.01 -> 6
+            abs < 1.0 -> 4
+            else -> 2
+        }
+    return toCommaFormattedString(decimals)
+}
+
+// Abbreviates large numbers with a K/M/B/T suffix — used for the CoinDetail stat
+// cards, where space is constrained and exact precision matters less than scannability.
+fun Double.formatAbbreviatedPrice(): String {
+    val abs = kotlin.math.abs(this)
+    val divisorAndSuffix =
+        when {
+            abs >= 1_000_000_000_000.0 -> 1_000_000_000_000.0 to "T"
+            abs >= 1_000_000_000.0 -> 1_000_000_000.0 to "B"
+            abs >= 1_000_000.0 -> 1_000_000.0 to "M"
+            abs >= 1_000.0 -> 1_000.0 to "K"
+            else -> null
+        } ?: return toCommaFormattedString(2)
+    val (divisor, suffix) = divisorAndSuffix
+    return "${(this / divisor).toCommaFormattedString(2)}$suffix"
+}
+
+// Formats an absolute price change with an explicit leading sign before the
+// dollar symbol (e.g. "+$983.35", "-$156.42"). Values that round to zero are
+// shown as neutral "$0.00" rather than "-$0.00" or "+$0.00".
+fun Double.formatPriceChange(): String {
+    val abs = kotlin.math.abs(this)
+    if (abs < 0.005) return "\$ 0.00"
+    val sign = if (this > 0) "+" else "-"
+    return "$sign\$ ${abs.toCommaFormattedString(2)}"
+}
 
 fun Double.toPercentString(): String {
     val abs = kotlin.math.abs(this)

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/CoinDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/CoinDetailScreen.kt
@@ -15,9 +15,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,6 +46,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cryptodanilo.project.core.presentation.util.formatAbbreviatedPrice
+import com.cryptodanilo.project.core.presentation.util.formatPriceChange
 import com.cryptodanilo.project.crypto.presentation.coinDetail.components.InfoCard
 import com.cryptodanilo.project.crypto.presentation.coinDetail.components.MarketsList
 import com.cryptodanilo.project.crypto.presentation.coinList.CoinListAction
@@ -51,7 +55,6 @@ import com.cryptodanilo.project.crypto.presentation.coinList.CoinListState
 import com.cryptodanilo.project.crypto.presentation.coinList.components.conditional
 import com.cryptodanilo.project.crypto.presentation.coinList.components.previewCoin
 import com.cryptodanilo.project.crypto.presentation.models.CoinUi
-import com.cryptodanilo.project.crypto.presentation.models.toDisplayableNumber
 import com.cryptodanilo.project.ui.theme.CryptoTrackerTheme
 import com.cryptodanilo.project.ui.theme.CryptoTrackerThemeProvider
 import com.cryptodanilo.project.ui.theme.greenBackground
@@ -182,22 +185,22 @@ private fun SharedTransitionScope.CoinDetailHeaderAndTabs(
         textAlign = TextAlign.Center,
         color = contentColor,
     )
+    Spacer(modifier = Modifier.height(CryptoTrackerTheme.spacing.medium))
     FlowRow(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
     ) {
         InfoCard(
             title = stringResource(Res.string.market_cap),
-            formattedValue = "$ ${coin.marketCapUsd.formatted}",
+            formattedValue = "$ ${coin.marketCapUsd.value.formatAbbreviatedPrice()}",
             icon = Res.drawable.stock,
         )
         InfoCard(
             title = stringResource(Res.string.price),
-            formattedValue = "$ ${coin.priceUsd.formatted}",
+            formattedValue = "$ ${coin.priceUsd.value.formatAbbreviatedPrice()}",
             icon = Res.drawable.dollar,
         )
-        val absoluteChangeFormatted =
-            ((coin.priceUsd.value) * (coin.changePercent24Hr.value / 100)).toDisplayableNumber()
+        val absoluteChangeValue = (coin.priceUsd.value) * (coin.changePercent24Hr.value / 100)
         val isPositiveChange = coin.changePercent24Hr.value > 0.0
         val contentColorInfoCard =
             if (isPositiveChange) {
@@ -207,7 +210,7 @@ private fun SharedTransitionScope.CoinDetailHeaderAndTabs(
             }
         InfoCard(
             title = stringResource(Res.string.change_last_24h),
-            formattedValue = absoluteChangeFormatted.formatted,
+            formattedValue = absoluteChangeValue.formatPriceChange(),
             icon =
                 if (isPositiveChange) {
                     Res.drawable.trending
@@ -217,7 +220,7 @@ private fun SharedTransitionScope.CoinDetailHeaderAndTabs(
             contentColor = contentColorInfoCard,
         )
     }
-
+    Spacer(modifier = Modifier.size(CryptoTrackerTheme.spacing.medium))
     // Chart | Markets tab switcher
     val tabShape = RoundedCornerShape(CryptoTrackerTheme.sizing.cornerSmall)
     Row(

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/LineChart.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/LineChart.kt
@@ -151,7 +151,12 @@ fun LineChart(
         val maxYLabelWidth = yLabelTextLayoutResults.maxOfOrNull { it.size.width } ?: 0
 
         val viewPortTopY = verticalPaddingPx + xLabelLineHeight + 10f
-        val viewPortRightX = size.width
+        // Reserve space on the right for half the last label's width (plus a small
+        // buffer) so its centered position never needs to be edge-clamped into the
+        // previous label's box — clamping without this room is what caused the last
+        // x-axis label to overlap its neighbor.
+        val rightPaddingPx = maxXLabelWidth / 2f + xAxisLabelSpacingPx
+        val viewPortRightX = size.width - rightPaddingPx
         val viewPortBottomY = viewPortTopY + viewPortHeightPx
         val viewPortLeftX = 2f * horizontalPaddingPx + maxYLabelWidth
 //        val viewPort = Rect(

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/components/InfoCard.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/components/InfoCard.kt
@@ -2,7 +2,9 @@ package com.cryptodanilo.project.crypto.presentation.coinDetail.components
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
@@ -19,6 +21,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.cryptodanilo.project.ui.theme.CryptoTrackerTheme
@@ -45,7 +48,7 @@ fun InfoCard(
     Card(
         modifier =
             modifier
-                .padding(CryptoTrackerTheme.spacing.small)
+                .padding(CryptoTrackerTheme.spacing.extraSmall)
                 .shadow(
                     elevation = CryptoTrackerTheme.sizing.cardElevation,
                     shape = RectangleShape,
@@ -60,46 +63,47 @@ fun InfoCard(
                 contentColor = contentColor,
             ),
     ) {
-        AnimatedContent(
-            targetState = icon,
-            label = "iconAnimation",
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) { icon ->
-            Icon(
-                painter = painterResource(icon),
-                contentDescription = title,
-                tint = contentColor,
-                modifier =
-                    Modifier
-                        .size(CryptoTrackerTheme.sizing.infoCardIconSize)
-                        .padding(top = CryptoTrackerTheme.sizing.infoCardInnerPadding),
-            )
+        Row(
+            modifier = Modifier.padding(CryptoTrackerTheme.sizing.infoCardInnerPadding),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(CryptoTrackerTheme.spacing.extraSmall),
+        ) {
+            AnimatedContent(
+                targetState = icon,
+                label = "iconAnimation",
+            ) { icon ->
+                Icon(
+                    painter = painterResource(icon),
+                    contentDescription = title,
+                    tint = contentColor,
+                    modifier = Modifier.size(CryptoTrackerTheme.sizing.infoCardIconSize),
+                )
+            }
+            Column(
+                modifier = Modifier.padding(start = CryptoTrackerTheme.spacing.extraSmall),
+            ) {
+                AnimatedContent(
+                    targetState = formattedValue,
+                    label = "valueAnimation",
+                ) { formattedValue ->
+                    Text(
+                        text = formattedValue,
+                        style = formattedTextStyle,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Text(
+                    text = title,
+                    textAlign = TextAlign.Start,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Light,
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
-        Spacer(modifier = Modifier.size(CryptoTrackerTheme.spacing.small))
-        AnimatedContent(
-            targetState = formattedValue,
-            label = "valueAnimation",
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) { formattedValue ->
-            Text(
-                text = formattedValue,
-                style = formattedTextStyle,
-                modifier = Modifier.padding(horizontal = CryptoTrackerTheme.spacing.medium),
-            )
-        }
-        Spacer(modifier = Modifier.size(CryptoTrackerTheme.spacing.small))
-        Text(
-            text = title,
-            textAlign = TextAlign.Center,
-            modifier =
-                Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(horizontal = CryptoTrackerTheme.spacing.medium)
-                    .padding(bottom = CryptoTrackerTheme.sizing.infoCardInnerPadding),
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Light,
-            color = contentColor,
-        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/components/MarketListItem.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/components/MarketListItem.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import com.cryptodanilo.project.crypto.presentation.models.DisplayableNumber
+import com.cryptodanilo.project.core.presentation.util.DisplayableNumber
 import com.cryptodanilo.project.crypto.presentation.models.MarketUi
 import com.cryptodanilo.project.crypto.presentation.models.asDollarString
 import com.cryptodanilo.project.crypto.presentation.models.pairWithTradesLine

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/components/MarketListItem.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinDetail/components/MarketListItem.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -61,7 +60,6 @@ private fun CompactMarketListItem(
             modifier
                 .fillMaxWidth()
                 .padding(horizontal = CryptoTrackerTheme.spacing.small, vertical = CryptoTrackerTheme.spacing.extraSmall)
-                .border(CryptoTrackerTheme.sizing.borderThin, CryptoTrackerTheme.colors.outlineVariant, RectangleShape)
                 .padding(CryptoTrackerTheme.sizing.marketItemInnerPadding),
     ) {
         Row(

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinList/components/CoinListItem.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinList/components/CoinListItem.kt
@@ -27,9 +27,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.sp
+import com.cryptodanilo.project.core.presentation.util.DisplayableNumber
+import com.cryptodanilo.project.core.presentation.util.formatFullPrice
 import com.cryptodanilo.project.crypto.domain.Coin
 import com.cryptodanilo.project.crypto.presentation.models.CoinUi
-import com.cryptodanilo.project.crypto.presentation.models.DisplayableNumber
 import com.cryptodanilo.project.crypto.presentation.models.toCoinUi
 import com.cryptodanilo.project.ui.theme.CryptoTrackerTheme
 import com.cryptodanilo.project.ui.theme.CryptoTrackerThemeProvider
@@ -103,7 +104,7 @@ fun SharedTransitionScope.CoinListItem(
         }
         Column(horizontalAlignment = Alignment.End) {
             Text(
-                text = "$ ${coin.priceUsd.formatted}",
+                text = "$ ${coin.priceUsd.value.formatFullPrice()}",
                 fontSize = 16.sp,
                 fontWeight = FontWeight.SemiBold,
                 color = contentColor,

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinList/components/PriceChange.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/coinList/components/PriceChange.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import com.cryptodanilo.project.crypto.presentation.models.DisplayableNumber
+import com.cryptodanilo.project.core.presentation.util.DisplayableNumber
 import com.cryptodanilo.project.ui.theme.CryptoTrackerTheme
 import com.cryptodanilo.project.ui.theme.CryptoTrackerThemeProvider
 import com.cryptodanilo.project.ui.theme.greenBackground

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/models/CoinUi.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/models/CoinUi.kt
@@ -1,6 +1,8 @@
 package com.cryptodanilo.project.crypto.presentation.models
 
+import com.cryptodanilo.project.core.presentation.util.DisplayableNumber
 import com.cryptodanilo.project.core.presentation.util.getDrawableIdForCoin
+import com.cryptodanilo.project.core.presentation.util.toDisplayableNumber
 import com.cryptodanilo.project.crypto.domain.Coin
 import com.cryptodanilo.project.crypto.presentation.coinDetail.DataPoint
 import org.jetbrains.compose.resources.DrawableResource
@@ -17,11 +19,6 @@ data class CoinUi(
     val coinPriceHistory: List<DataPoint> = emptyList(),
 )
 
-data class DisplayableNumber(
-    val value: Double,
-    val formatted: String,
-)
-
 fun Coin.toCoinUi(): CoinUi =
     CoinUi(
         id = id,
@@ -33,20 +30,5 @@ fun Coin.toCoinUi(): CoinUi =
         changePercent24Hr = changePercent24Hr.toDisplayableNumber(),
         iconRes = getDrawableIdForCoin(symbol),
     )
-
-fun Double.toDisplayableNumber(): DisplayableNumber {
-    val sign = if (this < 0) "-" else ""
-    val abs = kotlin.math.abs(this)
-    val integerPart =
-        abs
-            .toLong()
-            .toString()
-            .reversed()
-            .chunked(3)
-            .joinToString(",")
-            .reversed()
-    val fractionalPart = ((abs - abs.toLong()) * 100).toLong().toString().padStart(2, '0')
-    return DisplayableNumber(value = this, formatted = "$sign$integerPart.$fractionalPart")
-}
 
 fun DisplayableNumber.asDollarString(): String = "$ $formatted"

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/models/MarketUi.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/crypto/presentation/models/MarketUi.kt
@@ -1,7 +1,9 @@
 package com.cryptodanilo.project.crypto.presentation.models
 
+import com.cryptodanilo.project.core.presentation.util.DisplayableNumber
 import com.cryptodanilo.project.core.presentation.util.toAbbreviatedDollarString
 import com.cryptodanilo.project.core.presentation.util.toAbbreviatedString
+import com.cryptodanilo.project.core.presentation.util.toDisplayableNumber
 import com.cryptodanilo.project.core.presentation.util.toPercentString
 import com.cryptodanilo.project.core.presentation.util.toRelativeTimeString
 import com.cryptodanilo.project.crypto.domain.Market

--- a/shared/src/commonMain/kotlin/com/cryptodanilo/project/ui/theme/Sizing.kt
+++ b/shared/src/commonMain/kotlin/com/cryptodanilo/project/ui/theme/Sizing.kt
@@ -14,7 +14,7 @@ data class Sizing(
     val coinIconListSize: Dp = 85.dp,
     val coinDetailIconSize: Dp = 80.dp,
     val priceChangeIconSize: Dp = 20.dp,
-    val infoCardIconSize: Dp = 56.dp,
+    val infoCardIconSize: Dp = 48.dp,
     val backIconSize: Dp = 36.dp,
     val exchangeChipSize: Dp = 28.dp,
     // Borders

--- a/shared/src/wasmJsMain/kotlin/com/cryptodanilo/project/core/presentation/components/ComposeMultiplatformWatermark.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/cryptodanilo/project/core/presentation/components/ComposeMultiplatformWatermark.wasmJs.kt
@@ -3,22 +3,38 @@ package com.cryptodanilo.project.core.presentation.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.fromKeyword
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import com.cryptodanilo.project.ui.theme.CryptoTrackerTheme
 import cryptotrackerdanilo.shared.generated.resources.Res
 import cryptotrackerdanilo.shared.generated.resources.built_with
@@ -26,27 +42,69 @@ import cryptotrackerdanilo.shared.generated.resources.compose_multiplatform
 import cryptotrackerdanilo.shared.generated.resources.compose_multiplatform_name
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.roundToInt
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 actual fun ComposeMultiplatformWatermark() {
     val uriHandler = LocalUriHandler.current
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.BottomEnd,
-    ) {
+
+    // Position is an offset from the badge's default BottomEnd alignment, so it
+    // intentionally resets to that corner on page refresh instead of being persisted.
+    var offsetX by remember { mutableStateOf(0f) }
+    var offsetY by remember { mutableStateOf(0f) }
+    var isDragging by remember { mutableStateOf(false) }
+    var badgeSize by remember { mutableStateOf(IntSize.Zero) }
+
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val maxOffsetX = (constraints.maxWidth - badgeSize.width).coerceAtLeast(0).toFloat()
+        val maxOffsetY = (constraints.maxHeight - badgeSize.height).coerceAtLeast(0).toFloat()
+
         Row(
             modifier =
                 Modifier
-                    .padding(CryptoTrackerTheme.spacing.medium)
+                    .align(Alignment.BottomEnd)
+                    .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+                    .onSizeChanged { badgeSize = it }
+                    .pointerHoverIcon(
+                        if (isDragging) {
+                            PointerIcon.fromKeyword("grabbing")
+                        } else {
+                            PointerIcon.fromKeyword("grab")
+                        },
+                    ).pointerInput(Unit) {
+                        // detectDragGestures only calls onDragStart/onDragEnd once touch slop is
+                        // exceeded, so a zero-movement tap never reaches them. awaitFirstDown +
+                        // drag() fire for every gesture (including taps), letting us measure total
+                        // movement ourselves and decide tap vs. drag at release time.
+                        val dragThresholdPx = WATERMARK_DRAG_THRESHOLD.toPx()
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            var totalDragDistance = 0f
+                            isDragging = false
+                            drag(down.id) { change ->
+                                val dragAmount = change.positionChange()
+                                change.consume()
+                                totalDragDistance += dragAmount.getDistance()
+                                if (totalDragDistance > dragThresholdPx) {
+                                    isDragging = true
+                                }
+                                offsetX = (offsetX + dragAmount.x).coerceIn(-maxOffsetX, 0f)
+                                offsetY = (offsetY + dragAmount.y).coerceIn(-maxOffsetY, 0f)
+                            }
+                            if (!isDragging) {
+                                uriHandler.openUri(COMPOSE_MULTIPLATFORM_URL)
+                            }
+                            isDragging = false
+                        }
+                    }.padding(CryptoTrackerTheme.spacing.medium)
                     .clip(RoundedCornerShape(CryptoTrackerTheme.sizing.cornerFull))
                     .background(CryptoTrackerTheme.colors.surfaceContainerHigh)
                     .border(
                         width = CryptoTrackerTheme.sizing.borderThin,
                         color = CryptoTrackerTheme.colors.outline,
                         shape = RoundedCornerShape(CryptoTrackerTheme.sizing.cornerFull),
-                    ).clickable {
-                        uriHandler.openUri(COMPOSE_MULTIPLATFORM_URL)
-                    }.padding(
+                    ).padding(
                         horizontal = CryptoTrackerTheme.spacing.medium,
                         vertical = CryptoTrackerTheme.spacing.small,
                     ),

--- a/shared/src/wasmJsMain/kotlin/com/cryptodanilo/project/core/presentation/components/ComposeMultiplatformWatermarkConstants.kt
+++ b/shared/src/wasmJsMain/kotlin/com/cryptodanilo/project/core/presentation/components/ComposeMultiplatformWatermarkConstants.kt
@@ -1,4 +1,8 @@
 package com.cryptodanilo.project.core.presentation.components
 
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
 internal const val COMPOSE_MULTIPLATFORM_URL = "https://www.jetbrains.com/compose-multiplatform/"
 internal const val EXTERNAL_LINK_ARROW = "↗"
+internal val WATERMARK_DRAG_THRESHOLD: Dp = 8.dp


### PR DESCRIPTION
## Summary
- Separate full vs. abbreviated price formatting and fix sign placement
- Fix the chart's last x-axis label overlapping/clipping by reserving right-edge padding
- Remove the outer card border from mobile market rows, keeping only the row separator
- Make the wasmJs "Built with Compose Multiplatform" watermark badge draggable, with proper tap-vs-drag detection and on-screen clamping

## Screenshot / demo
<img width="1485" height="948" alt="image" src="https://github.com/user-attachments/assets/d973b46f-4477-46cd-894e-35947476fa11" />
<img width="1486" height="951" alt="image" src="https://github.com/user-attachments/assets/76faed75-39ca-455f-a13d-7d618950c192" />


## Test plan
- [ ] Verify price formatting on coin list and detail screens (full vs. abbreviated)
- [ ] Verify chart x-axis labels no longer overlap/clip on the right edge
- [ ] Verify markets tab mobile rows show only a separator line (no box) while rank badges keep their own box
- [ ] Verify the watermark badge can be dragged anywhere on screen (web target), stays clamped on screen, and tapping it (without dragging) still opens the Compose Multiplatform link